### PR TITLE
Fix Select Linked and partial face loops

### DIFF
--- a/Blender/ContextSelect.py
+++ b/Blender/ContextSelect.py
@@ -160,8 +160,10 @@ class OBJECT_OT_context_select(bpy.types.Operator):
 
         select_face(active_face)
 
-        bpy.ops.mesh.loop_multi_select('INVOKE_DEFAULT', ring=False)
-        bpy.ops.mesh.select_mode('INVOKE_DEFAULT', use_extend=False, use_expand=False, type='VERT')
+        #Must use ring=True because sometimes triangles touch against the active_face so loops won't complete.
+        bpy.ops.mesh.loop_multi_select('INVOKE_DEFAULT', ring=True)
+        #Must use Edge instead of Verts because if verts encompass a triangle it will select that face.
+        bpy.ops.mesh.select_mode('INVOKE_DEFAULT', use_extend=False, use_expand=False, type='EDGE')
         bpy.ops.mesh.select_mode('INVOKE_DEFAULT', use_extend=False, use_expand=False, type='FACE')
         two_loop_faces = [f.index for f in bm.faces if f.select]
 

--- a/Blender/ContextSelect.py
+++ b/Blender/ContextSelect.py
@@ -152,10 +152,21 @@ class OBJECT_OT_context_select(bpy.types.Operator):
 
         select_face(active_face)
 
+        bpy.ops.mesh.loop_multi_select('INVOKE_DEFAULT', ring=False)
+        bpy.ops.mesh.select_mode('INVOKE_DEFAULT', use_extend=False, use_expand=False, type='VERT')
+        bpy.ops.mesh.select_mode('INVOKE_DEFAULT', use_extend=False, use_expand=False, type='FACE')
+        two_loop_faces = [f.index for f in bm.faces if f.select]
+
+        select_face(active_face)
+
         if previous_active_face.index in loop_faces and not previous_active_face.index == active_face.index:
             if previous_active_face.index in relevant_neighbour_faces:
-                bpy.ops.mesh.edgering_select('INVOKE_DEFAULT', ring=False)
-            elif active_face.index in loop_faces:
+                bpy.ops.mesh.edgering_select('INVOKE_DEFAULT', ring=True)
+            elif active_face.index in two_loop_faces:
+                previous_active_face.select = True
+                bpy.ops.mesh.shortest_path_select(use_face_step=True)
+        elif previous_active_face.index in two_loop_faces and not previous_active_face.index == active_face.index: 
+            if active_face.index in two_loop_faces:
                 previous_active_face.select = True
                 bpy.ops.mesh.shortest_path_select(use_face_step=True)
         else:


### PR DESCRIPTION
See comments on Issue #10 
https://github.com/Stromberg90/Scripts/issues/10#issuecomment-599037673

This isn't the prettiest solution but it seems to work.

- Fix unintended triggering of Select Linked while in face mode 
- and make partial face loop selection (shortest_path_select) a little more reliable (can click next to any edge of a face) because sometimes it would not trigger at all due to Blender's edge-detection.

Limitations:
- Selecting a full face loop (edgering_select) still requires clicking next to the 'correct' edge of a face due to the built-in operator's edge detection 'feature'.  This is not changed from the way the addon currently behaves.