### PR TITLE
Boundary "loop" selection + selection state cleanup

### DIFF
--- a/Blender/ContextSelect.py
+++ b/Blender/ContextSelect.py
@@ -23,11 +23,11 @@ import bmesh
 bl_info = {
     "name": "Context Select",
     "category": "User",
-    "author": "Andreas Strømberg / MightyBOBcnc",
+    "author": "Andreas Strømberg / Chris Kohl",
     "wiki_url": "https://github.com/Stromberg90/Scripts/tree/master/Blender",
     "tracker_url": "https://github.com/Stromberg90/Scripts/issues",
     "blender": (2, 80, 0),
-    "version": (1, 2, 0)
+    "version": (1, 3, 0)
 }
 
 
@@ -131,6 +131,7 @@ class OBJECT_OT_context_select(bpy.types.Operator):
             component.select = True
             bm.select_history.add(active_vert) # Re-add active_vert to history to keep it active.
 
+        bm.select_flush_mode()
         bmesh.update_edit_mesh(me)
 
     def maya_face_select(self, context):
@@ -187,6 +188,7 @@ class OBJECT_OT_context_select(bpy.types.Operator):
             component.select = True
 
         bm.select_history.add(active_face)
+        bm.select_flush_mode()
         bmesh.update_edit_mesh(me)
 
     def maya_edge_select(self, context):
@@ -244,16 +246,27 @@ class OBJECT_OT_context_select(bpy.types.Operator):
                     else:
                         previous_active_edge.select = True
                         bpy.ops.mesh.shortest_path_select()
+                        
+                elif active_edge.is_boundary:
+                    boundary_edges = get_boundary_edge_loop(active_edge)
+                    for e in boundary_edges:
+                        e.select = True
 
                     bm.select_history.clear()
         else:
-            bpy.ops.mesh.edgering_select('INVOKE_DEFAULT', ring=False)
-            bm.select_history.clear()
+            if active_edge.is_boundary:
+                boundary_edges = get_boundary_edge_loop(active_edge)
+                for e in boundary_edges:
+                    e.select = True
+            else:
+                bpy.ops.mesh.edgering_select('INVOKE_DEFAULT', ring=False)
+                bm.select_history.clear()
 
         for component in selected_components:
             component.select = True
 
         bm.select_history.add(active_edge)
+        bm.select_flush_mode()
         bmesh.update_edit_mesh(me)
 
 
@@ -289,6 +302,28 @@ def select_face(active_face):
     bpy.ops.mesh.select_all(action='DESELECT')
     active_face.select = True
 
+def get_boundary_edge_loop(edge, max_edges=1000):
+    i=0
+    if edge.is_boundary:
+        first_edge = edge
+        cur_edge = edge
+    final_selection = []
+
+    while i < max_edges:
+        final_selection.append(cur_edge)
+        edge_verts = cur_edge.verts
+        new_edges = []
+
+        # From vertices in the current edge get connected edges if they're boundary.
+        new_edges = [e for v in edge_verts for e in v.link_edges[:] \
+        if e.is_boundary and e != cur_edge and not e in final_selection]
+        
+        if len(new_edges) == 0 or new_edges[0] == first_edge:
+            break
+        else:
+            cur_edge = new_edges[0]
+            i+=1
+    return final_selection
 
 def register():
     bpy.utils.register_class(ContextSelectPreferences)

--- a/Blender/ContextSelect.py
+++ b/Blender/ContextSelect.py
@@ -302,14 +302,12 @@ def select_face(active_face):
     bpy.ops.mesh.select_all(action='DESELECT')
     active_face.select = True
 
-def get_boundary_edge_loop(edge, max_edges=1000):
-    i=0
-    if edge.is_boundary:
-        first_edge = edge
-        cur_edge = edge
+def get_boundary_edge_loop(active_edge):
+    first_edge = active_edge
+    cur_edge = active_edge
     final_selection = []
 
-    while i < max_edges:
+    while True:
         final_selection.append(cur_edge)
         edge_verts = cur_edge.verts
         new_edges = []
@@ -322,7 +320,6 @@ def get_boundary_edge_loop(edge, max_edges=1000):
             break
         else:
             cur_edge = new_edges[0]
-            i+=1
     return final_selection
 
 def register():


### PR DESCRIPTION
Hi, me again.  I added a new function for selecting a boundary edge "loop" of connected edges like Maya's selection of a mesh's Border Edges.  It only selects the "loop" that is connected to the starting edge, not every boundary edge on the mesh.

![](https://i.imgur.com/B2rdlY8.gif)

There are two (three?) design questions that maybe should be answered. 
1: Should there be a Preference to enable/disable this?  I can see how some users would prefer for the boundary edge selection to terminate at corners or 'poles' where more than 2 faces connect at a boundary vertex but if the goal is to emulate Maya, well Maya doesn't terminate; it grabs the full border edge "loop".
2: The way the function is implemented right now it will only select up to 1000 edges in a boundary edge loop which is kind of a performance/safety failsafe.  Do we think that is okay or should we make it unlimited and let the user take responsibility for any performance issues?
2a: If we think a limit is sensible for performance reasons, should that be configurable in a preference or left at 1000?

-----
I also added a couple more selection flushes to keep the selection state 'happy' the way Blender likes, updated the author line, and the version number.