### PR TITLE
Update Edge_To_Curve.py

### DIFF
--- a/Blender/Edge_To_Curve.py
+++ b/Blender/Edge_To_Curve.py
@@ -21,11 +21,11 @@ bl_info = {
     "name": "Edges To Curve",
     "category": "Object",
     "description": "Converts selected edges into curve with extrusion",
-    "author": "Andreas Strømberg",
+    "author": "Andreas Strømberg, Chris Kohl",
     "wiki_url": "https://github.com/Stromberg90/Scripts/tree/master/Blender",
     "tracker_url": "https://github.com/Stromberg90/Scripts/issues",
     "blender": (2, 80, 0),
-    "version": (1, 0, 1)
+    "version": (1, 0, 2)
 }
 
 import bpy
@@ -60,6 +60,7 @@ class EventType:
 class ModalEdgeToCurve(bpy.types.Operator):
     bl_idname = "object.edge_to_curve"
     bl_label = "Edges To Curve"
+    bl_description = "Takes selected mesh edges and converts them into a curve."
     bl_options = {'REGISTER', 'UNDO'}
 
     @classmethod
@@ -134,13 +135,19 @@ class ModalEdgeToCurve(bpy.types.Operator):
             context.window_manager.modal_handler_add(self)
             return {'RUNNING_MODAL'}
 
+def EdgeToCurveMenuItem(self, context):
+    layout = self.layout
+    layout.separator()
+    layout.operator("object.edge_to_curve", text="Edges to Curve")
 
 def register():
     bpy.utils.register_class(ModalEdgeToCurve)
+    bpy.types.VIEW3D_MT_edit_mesh_edges.append(EdgeToCurveMenuItem)
 
 
 def unregister():
     bpy.utils.unregister_class(ModalEdgeToCurve)
+    bpy.types.VIEW3D_MT_edit_mesh_edges.remove(EdgeToCurveMenuItem)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Added the edge to curve operator to the end of the VIEW3D_MT_edit_mesh_edges menu when in mesh edge edit mode to allow it to show up in the operator search menu due to a change in the way that search functions in the latest Blender versions.

https://wiki.blender.org/wiki/Reference/Release_Notes/2.90/Python_API#Compatibility

Also added a bl_description for the operator's mouse hover text.