### PR TITLE
Vulkan fix

### DIFF
--- a/mesh_merge_tool/__init__.py
+++ b/mesh_merge_tool/__init__.py
@@ -106,8 +106,6 @@ class MergeToolPreferences(bpy.types.AddonPreferences):
         step=1,
         precision=2)
 
-    # TODO: Can we get colors from the user's active theme? E.G. how the Knife Tool does?
-    # Do we even want to? We'd want to select colors that have good contrast with the mesh, not the same colors as the mesh.
     start_color: FloatVectorProperty(name="Starting Color",
         default=(0.6, 0.0, 1.0, 1.0),
         size=4,
@@ -149,7 +147,6 @@ class MergeToolPreferences(bpy.types.AddonPreferences):
         nums.prop(self, "point_size")
         nums.prop(self, "edge_width")
         nums.prop(self, "line_width")
-#        nums.prop(self, "circ_radius")
 
         colors = layout.grid_flow(row_major=False, columns=0, even_columns=True, even_rows=False, align=False)
         colors.prop(self, "start_color")
@@ -249,8 +246,6 @@ class MergeTool(bpy.types.Operator):
 
         if event.alt or event.type in {'MIDDLEMOUSE', 'WHEELUPMOUSE', 'WHEELDOWNMOUSE'}:
             # Allow navigation when invoked from keybind instead of mouse
-            # TODO: Investigate github issue 41; someone requests a middle mouse option.
-            # TODO: It'd be nice if these keys could be user-defined, not hard-coded.
             return {'PASS_THROUGH'}
         elif event.type in {'ONE', 'A', 'F'} and event.value == 'PRESS':
             self.merge_location = 'FIRST'
@@ -263,10 +258,6 @@ class MergeTool(bpy.types.Operator):
                 self.m_coord = event.mouse_region_x, event.mouse_region_y
                 bpy.ops.view3d.select(extend=False, location=self.m_coord)
                 set_component(self, 'END')
-        # TODO: If people keybind the operator directly and don't have Wait for Input then they still need to
-        #       click to confirm the merge because it only follows this code path for LEFTMOUSE events.
-        #       It may be nice if we could let them define a key AND let it invoke upon key press and
-        #       execute this code path upon key release.
         elif event.type == 'LEFTMOUSE':
             main(self, context, event)
             if not self.started:
@@ -297,7 +288,6 @@ class MergeTool(bpy.types.Operator):
                         self.end_comp.select = True
                         self.bm.select_history.add(self.start_comp)
                         self.bm.select_history.add(self.end_comp)
-                        # TODO: Blender's uv "fixing" is too crude
                         bpy.ops.mesh.merge(type=self.merge_location, uvs=self.prefs.fix_uvs)
                     elif self.sel_mode == 'EDGE':
                         # Case of two fully separate edges
@@ -377,9 +367,6 @@ class MergeTool(bpy.types.Operator):
         return {'RUNNING_MODAL'}
 
     def invoke(self, context, event):
-    # TODO: You know, maybe we *could* support multi-select modes by detecting the TYPE of the active component rather than the selection mode.
-    # The only criteria would be that at least one actived mode is vert or edge. Though, if it's a face it could be unintuitive why it only seems to work "sometimes" when the cursor isn't in just the right place to grab a vert or edge.
-    # So really the first 3 logic tests would be exactly the same as below, and then when we got to the final Else check, that's where new logic would reside (because doing the existing logic first would let us short circuit needing extra checks).
         modes = context.tool_settings.mesh_select_mode
         if modes[0] and not modes[1] and not modes[2]:
             self.sel_mode = 'VERT'
@@ -393,10 +380,6 @@ class MergeTool(bpy.types.Operator):
             self.report({'WARNING'}, "Selection Mode must be Vertex or Edge only")
             return {'CANCELLED'}
 
-        # TODO: Wishlist: UV Editor support (would need an entirely separate tool + classes)
-        # BUG: There's an issue related to having multiple objects in edit mode where if object A is active and object B is inactive
-        #      then if you try to use the merge tool on object B then the first time it won't work. We need to check and set active
-        #      before doing anything else so that the tool will work the first time when object switching.
         if context.space_data.type == 'VIEW_3D':
             context.workspace.status_text_set("Left Click and drag to merge vertices or edges. Esc or Right Click to cancel. Modifier keys during drag: [1], [2], [3], [A], [C], [F], [L]")
 

--- a/mesh_merge_tool/__init__.py
+++ b/mesh_merge_tool/__init__.py
@@ -20,7 +20,7 @@ bl_info = {
     "name": "Merge Tool",
     "description": "An interactive tool for merging vertices and edges.",
     "author": "Andreas Strømberg, Chris Kohl",
-    "version": (1, 4, 0),
+    "version": (1, 5, 0),
     "blender": (2, 93, 0),
     "location": "View3D > TOOLS > Merge Tool",
     "warning": "",
@@ -31,12 +31,17 @@ bl_info = {
 
 
 import bpy
-import gpu
 import bmesh
 import os
 from mathutils import Vector
-from gpu_extras.presets import draw_circle_2d
-from gpu_extras.batch import batch_for_shader
+
+from importlib import reload
+if 'shaders' in globals():
+    reload(shaders)
+
+from .shaders import draw_callback_3d, draw_callback_2d
+from .util import find_center, set_component
+
 from bpy.props import (
     EnumProperty,
     StringProperty,
@@ -49,13 +54,6 @@ from bpy.props import (
 icon_dir = os.path.join(os.path.dirname(__file__), "icons")
 t_cursor = 'PAINT_CROSS'
 
-# Blender versions higher than 4.0 don't support 3D_UNIFORM_COLOR but versions below 3.4 require it
-if bpy.app.version[0] >= 4:
-    shader_type = 'UNIFORM_COLOR'
-elif bpy.app.version[0] == 3 and bpy.app.version[1] >= 4:
-        shader_type = 'UNIFORM_COLOR'
-else:
-    shader_type = '3D_UNIFORM_COLOR'
 
 classes = []
 
@@ -104,10 +102,12 @@ class MergeToolPreferences(bpy.types.AddonPreferences):
         description="Size of the circle cursor (VISUAL ONLY)",
         default=12.0,
         min=6.0,
-        max=100,
+        max=100.0,
         step=1,
         precision=2)
 
+    # TODO: Can we get colors from the user's active theme? E.G. how the Knife Tool does?
+    # Do we even want to? We'd want to select colors that have good contrast with the mesh, not the same colors as the mesh.
     start_color: FloatVectorProperty(name="Starting Color",
         default=(0.6, 0.0, 1.0, 1.0),
         size=4,
@@ -149,6 +149,7 @@ class MergeToolPreferences(bpy.types.AddonPreferences):
         nums.prop(self, "point_size")
         nums.prop(self, "edge_width")
         nums.prop(self, "line_width")
+#        nums.prop(self, "circ_radius")
 
         colors = layout.grid_flow(row_major=False, columns=0, even_columns=True, even_rows=False, align=False)
         colors.prop(self, "start_color")
@@ -156,247 +157,6 @@ class MergeToolPreferences(bpy.types.AddonPreferences):
         colors.prop(self, "line_color")
         colors.prop(self, "circ_color")
 classes.append(MergeToolPreferences)
-
-
-vertex_shader = '''
-    uniform mat4 u_ViewProjectionMatrix;
-
-    in vec3 position;
-    in float arcLength;
-
-    out float v_ArcLength;
-
-    void main()
-    {
-        v_ArcLength = arcLength;
-        gl_Position = u_ViewProjectionMatrix * vec4(position, 1.0f);
-    }
-'''
-
-fragment_shader = '''
-    uniform float u_Scale;
-    uniform vec4 u_Color;
-
-    in float v_ArcLength;
-    out vec4 FragColor;
-
-    void main()
-    {
-        if (step(sin(v_ArcLength * u_Scale), 0.5) == 1) discard;
-        FragColor = vec4(u_Color);
-    }
-'''
-
-
-class DrawPoint():
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.shader = None
-        self.coords = None
-        self.color = None
-
-    def draw(self):
-        batch = batch_for_shader(self.shader, 'POINTS', {"pos": self.coords})
-        self.shader.bind()
-        self.shader.uniform_float("color", self.color)
-        batch.draw(self.shader)
-
-    def add(self, shader, coords, color):
-        self.shader = shader
-        if isinstance(coords, Vector):
-            self.coords = [coords]
-        else:
-            self.coords = coords
-        self.color = color
-        self.draw()
-
-
-class DrawLine():
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.shader = None
-        self.coords = None
-        self.color = None
-
-    def draw(self):
-        batch = batch_for_shader(self.shader, 'LINES', {"pos": self.coords})
-        self.shader.bind()
-        self.shader.uniform_float("color", self.color)
-        batch.draw(self.shader)
-
-    def add(self, shader, coords, color):
-        self.shader = shader
-        self.coords = coords
-        self.color = color
-        self.draw()
-
-
-class DrawLineDashed():
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.shader = None
-        self.coords = None
-        self.color = None
-        self.arc_lengths = None
-
-    def draw(self):
-        batch = batch_for_shader(self.shader, 'LINES', {"position": self.coords, "arcLength": self.arc_lengths})
-        self.shader.bind()
-        matrix = bpy.context.region_data.perspective_matrix
-        self.shader.uniform_float("u_ViewProjectionMatrix", matrix)
-        self.shader.uniform_float("u_Scale", 50)
-        self.shader.uniform_float("u_Color", self.color)
-        batch.draw(self.shader)
-
-    def add(self, shader, coords, color):
-        self.shader = shader
-        self.coords = coords
-        self.color = color
-        self.arc_lengths = [0]
-        for a, b in zip(self.coords[:-1], self.coords[1:]):
-            self.arc_lengths.append(self.arc_lengths[-1] + (a - b).length)
-        self.draw()
-
-
-def draw_callback_3d(self, context):
-    if self.started and self.start_comp is not None:
-        gpu.state.point_size_set(self.prefs.point_size)
-        shader = gpu.shader.from_builtin(shader_type)
-        if self.end_comp is not None and self.end_comp != self.start_comp:
-            gpu.state.line_width_set(self.prefs.line_width)
-            if not self.multi_merge:
-                line_coords = [self.start_comp_transformed, self.end_comp_transformed]
-            else:
-                line_coords = []
-                vert_coords = []
-                if self.merge_location == 'CENTER':
-                    vert_list = [v.co for v in self.start_sel]
-                    if self.end_comp not in self.start_sel:
-                        vert_list.append(self.end_comp.co)
-                    for v in self.start_sel:
-                        line_coords.append(self.world_matrix @ v.co)
-                        line_coords.append(self.world_matrix @ find_center(vert_list))
-                        vert_coords.append(self.world_matrix @ v.co)
-                    line_coords.append(self.end_comp_transformed)
-                    line_coords.append(self.world_matrix @ find_center(vert_list))
-                elif self.merge_location == 'LAST':
-                    for v in self.start_sel:
-                        line_coords.append(self.world_matrix @ v.co)
-                        line_coords.append(self.end_comp_transformed)
-                        vert_coords.append(self.world_matrix @ v.co)
-                elif self.merge_location == 'FIRST':
-                    for v in self.start_sel:
-                        line_coords.append(self.world_matrix @ v.co)
-                        line_coords.append(self.start_comp_transformed)
-                        vert_coords.append(self.world_matrix @ v.co)
-                    line_coords.append(self.end_comp_transformed)
-                    line_coords.append(self.start_comp_transformed)
-
-            # Line that connects the start and end position (draw first so it's beneath the vertices)
-            if not self.multi_merge:
-                tool_line = DrawLine()
-                tool_line.add(shader, line_coords, self.prefs.line_color)
-            else:
-                shader_dashed = gpu.types.GPUShader(vertex_shader, fragment_shader)
-                tool_line = DrawLineDashed()
-                tool_line.add(shader_dashed, line_coords, self.prefs.line_color)
-
-            # Ending edge
-            if self.sel_mode == 'EDGE':
-                gpu.state.line_width_set(self.prefs.edge_width)
-                e1v = [self.world_matrix @ v.co for v in self.end_comp.verts]
-
-                end_edge = DrawLine()
-                if self.merge_location in ('FIRST', 'CENTER'):
-                    end_edge.add(shader, e1v, self.prefs.start_color)
-                else:
-                    end_edge.add(shader, e1v, self.prefs.end_color)
-
-            # Ending point
-            end_point = DrawPoint()
-            if self.multi_merge:
-                end_point.add(shader, vert_coords, self.prefs.start_color)
-            if self.merge_location in ('FIRST', 'CENTER'):
-                end_point.add(shader, self.end_comp_transformed, self.prefs.start_color)
-            else:
-                end_point.add(shader, self.end_comp_transformed, self.prefs.end_color)
-
-            # Middle point
-            if self.merge_location == 'CENTER':
-                if self.sel_mode == 'VERT':
-                    if self.multi_merge:
-                        midpoint = self.world_matrix @ find_center(vert_list)
-                    else:
-                        midpoint = self.world_matrix @ find_center([self.start_comp, self.end_comp])
-                elif self.sel_mode == 'EDGE':
-                    midpoint = self.world_matrix @ \
-                            find_center([find_center(self.start_comp), find_center(self.end_comp)])
-
-                mid_point = DrawPoint()
-                mid_point.add(shader, midpoint, self.prefs.end_color)
-
-        # Starting edge
-        if self.sel_mode == 'EDGE':
-            gpu.state.line_width_set(self.prefs.edge_width)
-            e0v = [self.world_matrix @ v.co for v in self.start_comp.verts]
-
-            start_edge = DrawLine()
-            if self.merge_location == 'FIRST':
-                start_edge.add(shader, e0v, self.prefs.end_color)
-            else:
-                start_edge.add(shader, e0v, self.prefs.start_color)
-
-        # Starting point
-        start_point = DrawPoint()
-        if self.merge_location == 'FIRST':
-            start_point.add(shader, self.start_comp_transformed, self.prefs.end_color)
-        else:
-            start_point.add(shader, self.start_comp_transformed, self.prefs.start_color)
-
-        gpu.state.line_width_set(1)
-        gpu.state.point_size_set(1)
-
-
-def draw_callback_2d(self, context):
-    # Have to add 1 for some reason in order to get proper number of segments.
-    # This could potentially also be a ratio with the radius.
-    circ_segments = 8 + 1
-    draw_circle_2d(self.m_coord, self.prefs.circ_color, self.prefs.circ_radius, segments=circ_segments)
-
-
-def find_center(source):
-    """Assumes that the input is an Edge or an ordered object holding vertices or Vectors"""
-    coords = []
-    if isinstance(source, bmesh.types.BMEdge):
-        coords = [source.verts[0].co, source.verts[1].co]
-    elif isinstance(source[0], bmesh.types.BMVert):
-        coords = [v.co for v in source]
-    elif isinstance(source[0], Vector):
-        coords = [v for v in source]
-
-    offset = Vector((0.0, 0.0, 0.0))
-    for v in coords:
-        offset = offset + v
-    return offset / len(coords)
-
-
-def set_component(self, mode):
-    selected_comp = None
-    selected_comp = self.bm.select_history.active
-
-    if selected_comp:
-        if mode == 'START':
-            self.start_comp = selected_comp  # Set the start component
-            if self.sel_mode == 'VERT':
-                self.start_comp_transformed = self.world_matrix @ self.start_comp.co
-            elif self.sel_mode == 'EDGE':
-                self.start_comp_transformed = self.world_matrix @ find_center(self.start_comp)
-        if mode == 'END':
-            self.end_comp = selected_comp  # Set the end component
-            if self.sel_mode == 'VERT':
-                self.end_comp_transformed = self.world_matrix @ self.end_comp.co
-            elif self.sel_mode == 'EDGE':
-                self.end_comp_transformed = self.world_matrix @ find_center(self.end_comp)
 
 
 def main(self, context, event):
@@ -489,6 +249,8 @@ class MergeTool(bpy.types.Operator):
 
         if event.alt or event.type in {'MIDDLEMOUSE', 'WHEELUPMOUSE', 'WHEELDOWNMOUSE'}:
             # Allow navigation when invoked from keybind instead of mouse
+            # TODO: Investigate github issue 41; someone requests a middle mouse option.
+            # TODO: It'd be nice if these keys could be user-defined, not hard-coded.
             return {'PASS_THROUGH'}
         elif event.type in {'ONE', 'A', 'F'} and event.value == 'PRESS':
             self.merge_location = 'FIRST'
@@ -501,6 +263,10 @@ class MergeTool(bpy.types.Operator):
                 self.m_coord = event.mouse_region_x, event.mouse_region_y
                 bpy.ops.view3d.select(extend=False, location=self.m_coord)
                 set_component(self, 'END')
+        # TODO: If people keybind the operator directly and don't have Wait for Input then they still need to
+        #       click to confirm the merge because it only follows this code path for LEFTMOUSE events.
+        #       It may be nice if we could let them define a key AND let it invoke upon key press and
+        #       execute this code path upon key release.
         elif event.type == 'LEFTMOUSE':
             main(self, context, event)
             if not self.started:
@@ -531,10 +297,13 @@ class MergeTool(bpy.types.Operator):
                         self.end_comp.select = True
                         self.bm.select_history.add(self.start_comp)
                         self.bm.select_history.add(self.end_comp)
+                        # TODO: Blender's uv "fixing" is too crude
                         bpy.ops.mesh.merge(type=self.merge_location, uvs=self.prefs.fix_uvs)
                     elif self.sel_mode == 'EDGE':
                         # Case of two fully separate edges
                         if not any([v for v in self.start_comp.verts if v in self.end_comp.verts]):
+                        # Bridge is a hack to let Blender deal with deciding
+                        # which vertices connect to each other so we don't have to
                             bridge = bmesh.ops.bridge_loops(self.bm, edges=(self.start_comp, self.end_comp))
                             new_e0 = bridge['edges'][0]
                             new_e1 = bridge['edges'][1]
@@ -608,6 +377,9 @@ class MergeTool(bpy.types.Operator):
         return {'RUNNING_MODAL'}
 
     def invoke(self, context, event):
+    # TODO: You know, maybe we *could* support multi-select modes by detecting the TYPE of the active component rather than the selection mode.
+    # The only criteria would be that at least one actived mode is vert or edge. Though, if it's a face it could be unintuitive why it only seems to work "sometimes" when the cursor isn't in just the right place to grab a vert or edge.
+    # So really the first 3 logic tests would be exactly the same as below, and then when we got to the final Else check, that's where new logic would reside (because doing the existing logic first would let us short circuit needing extra checks).
         modes = context.tool_settings.mesh_select_mode
         if modes[0] and not modes[1] and not modes[2]:
             self.sel_mode = 'VERT'
@@ -621,6 +393,10 @@ class MergeTool(bpy.types.Operator):
             self.report({'WARNING'}, "Selection Mode must be Vertex or Edge only")
             return {'CANCELLED'}
 
+        # TODO: Wishlist: UV Editor support (would need an entirely separate tool + classes)
+        # BUG: There's an issue related to having multiple objects in edit mode where if object A is active and object B is inactive
+        #      then if you try to use the merge tool on object B then the first time it won't work. We need to check and set active
+        #      before doing anything else so that the tool will work the first time when object switching.
         if context.space_data.type == 'VIEW_3D':
             context.workspace.status_text_set("Left Click and drag to merge vertices or edges. Esc or Right Click to cancel. Modifier keys during drag: [1], [2], [3], [A], [C], [F], [L]")
 
@@ -628,6 +404,7 @@ class MergeTool(bpy.types.Operator):
             self.world_matrix = bpy.context.object.matrix_world
             self.bm = bmesh.from_edit_mesh(self.me)
 
+            # Get starting selection, if any.
             if self.sel_mode == 'VERT' and context.object.data.total_vert_sel > 1:
                 self.start_sel = [v for v in self.bm.verts if v.select]
             elif self.sel_mode == 'EDGE' and context.object.data.total_edge_sel > 1:
@@ -682,6 +459,8 @@ class WorkSpaceMergeTool(bpy.types.WorkSpaceTool):
     bl_cursor = t_cursor
     bl_widget = None
     bl_keymap = (
+        ("mesh.merge_tool", {"ctrl": 1, "type": 'LEFTMOUSE', "value": 'PRESS'},
+        {"properties": [("merge_location", 'CENTER')]}),
         ("mesh.merge_tool", {"type": 'LEFTMOUSE', "value": 'PRESS'},
         {"properties": [("wait_for_input", False)]}),
     )

--- a/mesh_merge_tool/shaders.py
+++ b/mesh_merge_tool/shaders.py
@@ -8,19 +8,21 @@ from .util import find_center
 
 
 # Blender versions higher than 4.0 don't support 3D_UNIFORM_COLOR but versions below 3.4 require it
-if bpy.app.version[0] >= 4:
-    shader_type = 'UNIFORM_COLOR'
+# Blender versions below 4.5 don't support POINT_UNIFORM_COLOR
+if bpy.app.version[0] == 5:
+    line_type = 'POLYLINE_UNIFORM_COLOR'
+    point_type = 'POINT_UNIFORM_COLOR'
+elif bpy.app.version[0] == 4:
+    line_type = 'POLYLINE_UNIFORM_COLOR'
+    point_type = 'UNIFORM_COLOR'
+    if bpy.app.version[1] >= 5:
+        point_type = 'POINT_UNIFORM_COLOR'
 elif bpy.app.version[0] == 3 and bpy.app.version[1] >= 4:
-        shader_type = 'UNIFORM_COLOR'
+    line_type = 'POLYLINE_UNIFORM_COLOR'
+    point_type = 'UNIFORM_COLOR'
 else:
-    shader_type = '3D_UNIFORM_COLOR'
-
-# TODO: Must try/except a check of the GPU backend to retain compatibility with opengl while also supporting the new vulkan bakend
-# (I don't know how old the system.gpu_backend property is, so if it doesn't exist, then default to opengl)
-# I could literally just query this on the Merge Tool's oldest supported blender version
-# bpy.context.preferences.system.gpu_backend
-# Unsupported: 2.93, 3.4
-# Supported: 3.5
+    line_type = '3D_POLYLINE_UNIFORM_COLOR'
+    point_type = '3D_UNIFORM_COLOR'
 
 try:
     # gpu_backend was added in 3.5
@@ -29,7 +31,7 @@ try:
 except:
     # Assume Opengl for older versions
     backend = 'OPENGL'
-    print("gpu_backend not present")
+# Pray that Metal works with Opengl code
 if backend != 'VULKAN':
     backend = 'OPENGL'
 
@@ -76,6 +78,10 @@ class DrawPoint():
         batch = batch_for_shader(self.shader, 'POINTS', {"pos": self.coords})
         self.shader.bind()
         self.shader.uniform_float("color", self.color)
+        try:  # Needed for Vulkan. Only applicable to Blender >= 4.5
+            self.shader.uniform_float("size", self.size)
+        except:
+            pass
         batch.draw(self.shader)
 
     def add(self, shader, coords, size, color):
@@ -98,9 +104,12 @@ class DrawLine():
         self.color = None
 
     def draw(self):
+        region = bpy.context.region
         batch = batch_for_shader(self.shader, 'LINES', {"pos": self.coords})
         self.shader.bind()
+        self.shader.uniform_float("viewportSize", (region.width, region.height))
         self.shader.uniform_float("color", self.color)
+        self.shader.uniform_float("lineWidth", self.width)
         batch.draw(self.shader)
 
     def add(self, shader, coords, width, color):
@@ -142,8 +151,10 @@ class DrawLineDashed():
 
 def draw_callback_3d(self, context):
     if self.started and self.start_comp is not None:
+        gpu.state.blend_set("ALPHA")
         gpu.state.point_size_set(self.prefs.point_size)
-        shader = gpu.shader.from_builtin(shader_type)
+        shader_line = gpu.shader.from_builtin(line_type)
+        shader_point = gpu.shader.from_builtin(point_type)
         if self.end_comp is not None and self.end_comp != self.start_comp:
             gpu.state.line_width_set(self.prefs.line_width)
             if not self.multi_merge:
@@ -177,7 +188,7 @@ def draw_callback_3d(self, context):
             # Line that connects the start and end position (draw first so it's beneath the vertices)
             if not self.multi_merge:
                 tool_line = DrawLine()
-                tool_line.add(shader, line_coords, self.prefs.line_width, self.prefs.line_color)
+                tool_line.add(shader_line, line_coords, self.prefs.line_width, self.prefs.line_color)
             else:
                 shader_dashed = gpu.types.GPUShader(vertex_shader, fragment_shader)
                 tool_line = DrawLineDashed()
@@ -190,23 +201,23 @@ def draw_callback_3d(self, context):
 
                 end_edge = DrawLine()
                 if self.merge_location in ('FIRST', 'CENTER'):
-                    end_edge.add(shader, e1v, self.prefs.edge_width, self.prefs.start_color)
+                    end_edge.add(shader_line, e1v, self.prefs.edge_width, self.prefs.start_color)
                 else:
-                    end_edge.add(shader, e1v, self.prefs.edge_width, self.prefs.end_color)
+                    end_edge.add(shader_line, e1v, self.prefs.edge_width, self.prefs.end_color)
 
             # Ending point
             end_point = DrawPoint()
             if self.multi_merge:
-                end_point.add(shader, vert_coords, self.prefs.point_size, self.prefs.start_color)
+                end_point.add(shader_point, vert_coords, self.prefs.point_size, self.prefs.start_color)
             if self.merge_location in ('FIRST', 'CENTER'):
-                end_point.add(shader, self.end_comp_transformed, self.prefs.point_size, self.prefs.start_color)
+                end_point.add(shader_point, self.end_comp_transformed, self.prefs.point_size, self.prefs.start_color)
             else:
-                end_point.add(shader, self.end_comp_transformed, self.prefs.point_size, self.prefs.end_color)
+                end_point.add(shader_point, self.end_comp_transformed, self.prefs.point_size, self.prefs.end_color)
 #            if self.merge_location in ('FIRST', 'CENTER'):  # There has to be a better way of doing this.
 #                point_color = self.prefs.start_color
 #            else:
 #                point_color = self.prefs.end_color
-#            end_point.add(shader, self.end_comp_transformed, self.prefs.point_size, point_color)
+#            end_point.add(shader_point, self.end_comp_transformed, self.prefs.point_size, point_color)
 
             # Middle point
             if self.merge_location == 'CENTER':
@@ -220,7 +231,7 @@ def draw_callback_3d(self, context):
                             find_center([find_center(self.start_comp), find_center(self.end_comp)])
 
                 mid_point = DrawPoint()
-                mid_point.add(shader, midpoint, self.prefs.point_size, self.prefs.end_color)
+                mid_point.add(shader_point, midpoint, self.prefs.point_size, self.prefs.end_color)
 
         # Starting edge
         if self.sel_mode == 'EDGE':
@@ -229,19 +240,20 @@ def draw_callback_3d(self, context):
 
             start_edge = DrawLine()
             if self.merge_location == 'FIRST':
-                start_edge.add(shader, e0v, self.prefs.edge_width, self.prefs.end_color)
+                start_edge.add(shader_line, e0v, self.prefs.edge_width, self.prefs.end_color)
             else:
-                start_edge.add(shader, e0v, self.prefs.edge_width, self.prefs.start_color)
+                start_edge.add(shader_line, e0v, self.prefs.edge_width, self.prefs.start_color)
 
         # Starting point
         start_point = DrawPoint()
         if self.merge_location == 'FIRST':
-            start_point.add(shader, self.start_comp_transformed, self.prefs.point_size, self.prefs.end_color)
+            start_point.add(shader_point, self.start_comp_transformed, self.prefs.point_size, self.prefs.end_color)
         else:
-            start_point.add(shader, self.start_comp_transformed, self.prefs.point_size, self.prefs.start_color)
+            start_point.add(shader_point, self.start_comp_transformed, self.prefs.point_size, self.prefs.start_color)
 
         gpu.state.line_width_set(1.0)
         gpu.state.point_size_set(1.0)
+        gpu.state.blend_set('NONE')
 
 
 def draw_callback_2d(self, context):

--- a/mesh_merge_tool/shaders.py
+++ b/mesh_merge_tool/shaders.py
@@ -1,0 +1,251 @@
+"""Shader related stuff."""
+import bpy
+import gpu
+from mathutils import Vector
+from gpu_extras.presets import draw_circle_2d
+from gpu_extras.batch import batch_for_shader
+from .util import find_center
+
+
+# Blender versions higher than 4.0 don't support 3D_UNIFORM_COLOR but versions below 3.4 require it
+if bpy.app.version[0] >= 4:
+    shader_type = 'UNIFORM_COLOR'
+elif bpy.app.version[0] == 3 and bpy.app.version[1] >= 4:
+        shader_type = 'UNIFORM_COLOR'
+else:
+    shader_type = '3D_UNIFORM_COLOR'
+
+# TODO: Must try/except a check of the GPU backend to retain compatibility with opengl while also supporting the new vulkan bakend
+# (I don't know how old the system.gpu_backend property is, so if it doesn't exist, then default to opengl)
+# I could literally just query this on the Merge Tool's oldest supported blender version
+# bpy.context.preferences.system.gpu_backend
+# Unsupported: 2.93, 3.4
+# Supported: 3.5
+
+try:
+    # gpu_backend was added in 3.5
+    # Valid return results are ('OPENGL', 'METAL', 'VULKAN')
+    backend = bpy.context.preferences.system.gpu_backend
+except:
+    # Assume Opengl for older versions
+    backend = 'OPENGL'
+    print("gpu_backend not present")
+if backend != 'VULKAN':
+    backend = 'OPENGL'
+
+
+vertex_shader = '''
+    uniform mat4 u_ViewProjectionMatrix;
+
+    in vec3 position;
+    in float arcLength;
+
+    out float v_ArcLength;
+
+    void main()
+    {
+        v_ArcLength = arcLength;
+        gl_Position = u_ViewProjectionMatrix * vec4(position, 1.0f);
+    }
+'''
+
+fragment_shader = '''
+    uniform float u_Scale;
+    uniform vec4 u_Color;
+
+    in float v_ArcLength;
+    out vec4 FragColor;
+
+    void main()
+    {
+        if (step(sin(v_ArcLength * u_Scale), 0.5) == 1) discard;
+        FragColor = vec4(u_Color);
+    }
+'''
+
+
+class DrawPoint():
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.shader = None
+        self.coords = None
+        self.size = None
+        self.color = None
+
+    def draw(self):
+        batch = batch_for_shader(self.shader, 'POINTS', {"pos": self.coords})
+        self.shader.bind()
+        self.shader.uniform_float("color", self.color)
+        batch.draw(self.shader)
+
+    def add(self, shader, coords, size, color):
+        self.shader = shader
+        if isinstance(coords, Vector):
+            self.coords = [coords]
+        else:
+            self.coords = coords
+        self.size = size
+        self.color = color
+        self.draw()
+
+
+class DrawLine():
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.shader = None
+        self.coords = None
+        self.width = None
+        self.color = None
+
+    def draw(self):
+        batch = batch_for_shader(self.shader, 'LINES', {"pos": self.coords})
+        self.shader.bind()
+        self.shader.uniform_float("color", self.color)
+        batch.draw(self.shader)
+
+    def add(self, shader, coords, width, color):
+        self.shader = shader
+        self.coords = coords
+        self.width = width
+        self.color = color
+        self.draw()
+
+
+class DrawLineDashed():
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.shader = None
+        self.coords = None
+        self.width = None
+        self.color = None
+        self.arc_lengths = None
+
+    def draw(self):
+        batch = batch_for_shader(self.shader, 'LINES', {"position": self.coords, "arcLength": self.arc_lengths})
+        self.shader.bind()
+        matrix = bpy.context.region_data.perspective_matrix
+        self.shader.uniform_float("u_ViewProjectionMatrix", matrix)
+        self.shader.uniform_float("u_Scale", 50)
+        self.shader.uniform_float("u_Color", self.color)
+        batch.draw(self.shader)
+
+    def add(self, shader, coords, width, color):
+        self.shader = shader
+        self.coords = coords 
+        self.width = width
+        self.color = color
+        self.arc_lengths = [0]
+        for a, b in zip(self.coords[:-1], self.coords[1:]):
+            self.arc_lengths.append(self.arc_lengths[-1] + (a - b).length)
+        self.draw()
+
+
+def draw_callback_3d(self, context):
+    if self.started and self.start_comp is not None:
+        gpu.state.point_size_set(self.prefs.point_size)
+        shader = gpu.shader.from_builtin(shader_type)
+        if self.end_comp is not None and self.end_comp != self.start_comp:
+            gpu.state.line_width_set(self.prefs.line_width)
+            if not self.multi_merge:
+                line_coords = [self.start_comp_transformed, self.end_comp_transformed]
+            else:
+                line_coords = []
+                vert_coords = []
+                if self.merge_location == 'CENTER':
+                    vert_list = [v.co for v in self.start_sel]
+                    if self.end_comp not in self.start_sel:
+                        vert_list.append(self.end_comp.co)
+                    for v in self.start_sel:
+                        line_coords.append(self.world_matrix @ v.co)
+                        line_coords.append(self.world_matrix @ find_center(vert_list))
+                        vert_coords.append(self.world_matrix @ v.co)
+                    line_coords.append(self.end_comp_transformed)
+                    line_coords.append(self.world_matrix @ find_center(vert_list))
+                elif self.merge_location == 'LAST':
+                    for v in self.start_sel:
+                        line_coords.append(self.world_matrix @ v.co)
+                        line_coords.append(self.end_comp_transformed)
+                        vert_coords.append(self.world_matrix @ v.co)
+                elif self.merge_location == 'FIRST':
+                    for v in self.start_sel:
+                        line_coords.append(self.world_matrix @ v.co)
+                        line_coords.append(self.start_comp_transformed)
+                        vert_coords.append(self.world_matrix @ v.co)
+                    line_coords.append(self.end_comp_transformed)
+                    line_coords.append(self.start_comp_transformed)
+
+            # Line that connects the start and end position (draw first so it's beneath the vertices)
+            if not self.multi_merge:
+                tool_line = DrawLine()
+                tool_line.add(shader, line_coords, self.prefs.line_width, self.prefs.line_color)
+            else:
+                shader_dashed = gpu.types.GPUShader(vertex_shader, fragment_shader)
+                tool_line = DrawLineDashed()
+                tool_line.add(shader_dashed, line_coords, self.prefs.line_width, self.prefs.line_color)
+
+            # Ending edge
+            if self.sel_mode == 'EDGE':
+                gpu.state.line_width_set(self.prefs.edge_width)
+                e1v = [self.world_matrix @ v.co for v in self.end_comp.verts]
+
+                end_edge = DrawLine()
+                if self.merge_location in ('FIRST', 'CENTER'):
+                    end_edge.add(shader, e1v, self.prefs.edge_width, self.prefs.start_color)
+                else:
+                    end_edge.add(shader, e1v, self.prefs.edge_width, self.prefs.end_color)
+
+            # Ending point
+            end_point = DrawPoint()
+            if self.multi_merge:
+                end_point.add(shader, vert_coords, self.prefs.point_size, self.prefs.start_color)
+            if self.merge_location in ('FIRST', 'CENTER'):
+                end_point.add(shader, self.end_comp_transformed, self.prefs.point_size, self.prefs.start_color)
+            else:
+                end_point.add(shader, self.end_comp_transformed, self.prefs.point_size, self.prefs.end_color)
+#            if self.merge_location in ('FIRST', 'CENTER'):  # There has to be a better way of doing this.
+#                point_color = self.prefs.start_color
+#            else:
+#                point_color = self.prefs.end_color
+#            end_point.add(shader, self.end_comp_transformed, self.prefs.point_size, point_color)
+
+            # Middle point
+            if self.merge_location == 'CENTER':
+                if self.sel_mode == 'VERT':
+                    if self.multi_merge:
+                        midpoint = self.world_matrix @ find_center(vert_list)
+                    else:
+                        midpoint = self.world_matrix @ find_center([self.start_comp, self.end_comp])
+                elif self.sel_mode == 'EDGE':
+                    midpoint = self.world_matrix @ \
+                            find_center([find_center(self.start_comp), find_center(self.end_comp)])
+
+                mid_point = DrawPoint()
+                mid_point.add(shader, midpoint, self.prefs.point_size, self.prefs.end_color)
+
+        # Starting edge
+        if self.sel_mode == 'EDGE':
+            gpu.state.line_width_set(self.prefs.edge_width)
+            e0v = [self.world_matrix @ v.co for v in self.start_comp.verts]
+
+            start_edge = DrawLine()
+            if self.merge_location == 'FIRST':
+                start_edge.add(shader, e0v, self.prefs.edge_width, self.prefs.end_color)
+            else:
+                start_edge.add(shader, e0v, self.prefs.edge_width, self.prefs.start_color)
+
+        # Starting point
+        start_point = DrawPoint()
+        if self.merge_location == 'FIRST':
+            start_point.add(shader, self.start_comp_transformed, self.prefs.point_size, self.prefs.end_color)
+        else:
+            start_point.add(shader, self.start_comp_transformed, self.prefs.point_size, self.prefs.start_color)
+
+        gpu.state.line_width_set(1.0)
+        gpu.state.point_size_set(1.0)
+
+
+def draw_callback_2d(self, context):
+    # Have to add 1 for some reason in order to get proper number of segments.
+    # This could potentially also be a ratio with the radius.
+    circ_segments = 8 + 1
+    draw_circle_2d(self.m_coord, self.prefs.circ_color, self.prefs.circ_radius, segments=circ_segments)

--- a/mesh_merge_tool/shaders.py
+++ b/mesh_merge_tool/shaders.py
@@ -9,7 +9,7 @@ from .util import find_center
 
 # Blender versions higher than 4.0 don't support 3D_UNIFORM_COLOR but versions below 3.4 require it
 # Blender versions below 4.5 don't support POINT_UNIFORM_COLOR
-if bpy.app.version[0] == 5:
+if bpy.app.version[0] >= 5:
     line_type = 'POLYLINE_UNIFORM_COLOR'
     point_type = 'POINT_UNIFORM_COLOR'
 elif bpy.app.version[0] == 4:
@@ -31,39 +31,70 @@ try:
 except:
     # Assume Opengl for older versions
     backend = 'OPENGL'
-# Pray that Metal works with Opengl code
-if backend != 'VULKAN':
-    backend = 'OPENGL'
 
+# Dashed lines
+# gpu.types.GPUShader is deprecated on Vulkan in 4.5 and completely removed in 5.0
+if backend == 'VULKAN' or bpy.app.version[0] >= 5:
+    vert_out = gpu.types.GPUStageInterfaceInfo("my_interface")
+    vert_out.smooth('FLOAT', "v_ArcLength")
 
-vertex_shader = '''
-    uniform mat4 u_ViewProjectionMatrix;
+    shader_info = gpu.types.GPUShaderCreateInfo()
+    shader_info.push_constant('MAT4', "u_ViewProjectionMatrix")
+    shader_info.push_constant('FLOAT', "u_Scale")
+    shader_info.push_constant('VEC4', "u_Color")
+    shader_info.vertex_in(0, 'VEC3', "position")
+    shader_info.vertex_in(1, 'FLOAT', "arcLength")
+    shader_info.vertex_out(vert_out)
+    shader_info.fragment_out(0, 'VEC4', "FragColor")
 
-    in vec3 position;
-    in float arcLength;
+    shader_info.vertex_source(
+        "void main()"
+        "{"
+        "  v_ArcLength = arcLength;"
+        "  gl_Position = u_ViewProjectionMatrix * vec4(position, 1.0f);"
+        "}"
+    )
 
-    out float v_ArcLength;
+    shader_info.fragment_source(
+        "void main()"
+        "{"
+        "  if (step(sin(v_ArcLength * u_Scale), 0.5) == 1) discard;"
+        "  FragColor = vec4(u_Color);"
+        "}"
+    )
 
-    void main()
-    {
-        v_ArcLength = arcLength;
-        gl_Position = u_ViewProjectionMatrix * vec4(position, 1.0f);
-    }
-'''
+    shader_v = gpu.shader.create_from_info(shader_info)
+    del vert_out
+    del shader_info
+else:
+    vertex_shader = '''
+        uniform mat4 u_ViewProjectionMatrix;
 
-fragment_shader = '''
-    uniform float u_Scale;
-    uniform vec4 u_Color;
+        in vec3 position;
+        in float arcLength;
 
-    in float v_ArcLength;
-    out vec4 FragColor;
+        out float v_ArcLength;
 
-    void main()
-    {
-        if (step(sin(v_ArcLength * u_Scale), 0.5) == 1) discard;
-        FragColor = vec4(u_Color);
-    }
-'''
+        void main()
+        {
+            v_ArcLength = arcLength;
+            gl_Position = u_ViewProjectionMatrix * vec4(position, 1.0f);
+        }
+    '''
+
+    fragment_shader = '''
+        uniform float u_Scale;
+        uniform vec4 u_Color;
+
+        in float v_ArcLength;
+        out vec4 FragColor;
+
+        void main()
+        {
+            if (step(sin(v_ArcLength * u_Scale), 0.5) == 1) discard;
+            FragColor = vec4(u_Color);
+        }
+    '''
 
 
 class DrawPoint():
@@ -190,7 +221,10 @@ def draw_callback_3d(self, context):
                 tool_line = DrawLine()
                 tool_line.add(shader_line, line_coords, self.prefs.line_width, self.prefs.line_color)
             else:
-                shader_dashed = gpu.types.GPUShader(vertex_shader, fragment_shader)
+                if backend == 'VULKAN' or bpy.app.version[0] >= 5:
+                    shader_dashed = shader_v
+                else:
+                    shader_dashed = gpu.types.GPUShader(vertex_shader, fragment_shader)
                 tool_line = DrawLineDashed()
                 tool_line.add(shader_dashed, line_coords, self.prefs.line_width, self.prefs.line_color)
 
@@ -213,11 +247,6 @@ def draw_callback_3d(self, context):
                 end_point.add(shader_point, self.end_comp_transformed, self.prefs.point_size, self.prefs.start_color)
             else:
                 end_point.add(shader_point, self.end_comp_transformed, self.prefs.point_size, self.prefs.end_color)
-#            if self.merge_location in ('FIRST', 'CENTER'):  # There has to be a better way of doing this.
-#                point_color = self.prefs.start_color
-#            else:
-#                point_color = self.prefs.end_color
-#            end_point.add(shader_point, self.end_comp_transformed, self.prefs.point_size, point_color)
 
             # Middle point
             if self.merge_location == 'CENTER':

--- a/mesh_merge_tool/util.py
+++ b/mesh_merge_tool/util.py
@@ -1,0 +1,38 @@
+"""Helper utilities."""
+import bmesh
+from mathutils import Vector
+
+
+def find_center(source):
+    """Assumes that the input is an Edge or an ordered object holding vertices or Vectors"""
+    coords = []
+    if isinstance(source, bmesh.types.BMEdge):
+        coords = [source.verts[0].co, source.verts[1].co]
+    elif isinstance(source[0], bmesh.types.BMVert):
+        coords = [v.co for v in source]
+    elif isinstance(source[0], Vector):
+        coords = [v for v in source]
+
+    offset = Vector((0.0, 0.0, 0.0))
+    for v in coords:
+        offset = offset + v
+    return offset / len(coords)
+
+
+def set_component(self, mode):
+    selected_comp = None
+    selected_comp = self.bm.select_history.active
+
+    if selected_comp:
+        if mode == 'START':
+            self.start_comp = selected_comp  # Set the start component
+            if self.sel_mode == 'VERT':
+                self.start_comp_transformed = self.world_matrix @ self.start_comp.co
+            elif self.sel_mode == 'EDGE':
+                self.start_comp_transformed = self.world_matrix @ find_center(self.start_comp)
+        if mode == 'END':
+            self.end_comp = selected_comp  # Set the end component
+            if self.sel_mode == 'VERT':
+                self.end_comp_transformed = self.world_matrix @ self.end_comp.co
+            elif self.sel_mode == 'EDGE':
+                self.end_comp_transformed = self.world_matrix @ find_center(self.end_comp)


### PR DESCRIPTION
- Initial support for rendering our overlay points and lines in Vulkan
- Fixes #51 (mostly; we lose the ability to control width of dashed lines in multi-merge. Will keep looking in #52 )
- Incidentally fixes #39 (mostly; dashed lines still don't have anti-aliasing in multi-merge)
- NOTE: We do not support the incomplete, experimental Vulkan backend in Blender 4.3 and 4.4. Proper Vulkan support begins with Blender 4.5.